### PR TITLE
Implement custom_attachment

### DIFF
--- a/src/types/chat/attachment/custom.rs
+++ b/src/types/chat/attachment/custom.rs
@@ -168,11 +168,11 @@ pub struct CustomInfo {
     #[serde(rename = "LOCK")]
     secure: Option<bool>,
     #[serde(rename = "FW")]
-    fw: Option<bool>, // Its name should be changed.
+    fw: Option<bool>,
     #[serde(rename = "RF")]
-    r#ref: String, // Its name must be changed!
+    reference: String,
     #[serde(rename = "AD")]
-    ad: Option<bool>, // Maybe is_ad?
+    ad: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/src/types/chat/attachment/custom.rs
+++ b/src/types/chat/attachment/custom.rs
@@ -1,0 +1,126 @@
+pub enum CustomType {
+    Feed,
+    List,
+    Commerce,
+    Carousel,
+}
+
+pub enum ButtonStyle {
+    Horizontal,
+    Vertical,
+}
+
+pub enum ButtonDisplayTarget {
+    All,
+    Sender,
+    Receiver,
+}
+
+pub enum ImageCropStyle {
+    Square = 0,
+    None = 1,
+}
+
+pub struct TextFragment {
+    text: String,
+    description: String,
+}
+
+pub struct LinkFragment {
+    windows_link: String,
+    macos_link: String,
+    android_link: String,
+    ios_link: String,
+}
+
+pub struct ImageFragment {
+    url: String,
+    width: u32,
+    height: u32,
+    crop_style: ImageCropStyle,
+    is_live: bool,
+    playtime: u32,
+}
+
+pub struct ButtonFragment {
+    text: String,
+    display_target: Option<ButtonDisplayTarget>,
+    link: LinkFragment,
+}
+
+pub struct SocialFragment {
+    link: u32,
+    comment: u32,
+    share: u32,
+    view: u32,
+    subscriber: u32,
+}
+
+pub struct ProfileFragment {
+    description: TextFragment,
+    link: LinkFragment,
+    background_image: ImageFragment,
+    thumbnail_image: ImageFragment,
+}
+
+pub struct CustomContent { }
+
+pub struct CustomFeedContent {
+    description: TextFragment,
+    button_style: ButtonStyle,
+    button_list: Vec<ButtonFragment>,
+    thumbnail_list: Vec<ImageFragment>,
+    thumbnail_count: u32,
+    text_link: Option<LinkFragment>,
+    full_text: bool,
+    link: Option<LinkFragment>,
+    profile: Option<ProfileFragment>,
+    social: Option<SocialFragment>,
+}
+
+pub struct CarouselCover {
+    text: TextFragment,
+    thumbnail_image: Option<ImageFragment>,
+    background_image: Option<ImageFragment>,
+    link: Option<LinkFragment>,
+}
+
+pub struct CustomCarouselContent {
+    card_type: CustomType,
+    content_list: Vec<CustomContent>,
+    content_head: Option<CarouselCover>,
+    content_tail: Option<CarouselCover>,
+}
+
+pub struct CustomInfo {
+    message: String,
+    custom_type: CustomType,
+    service_id: String,
+    provider_id: String,
+    android_version: String,
+    ios_version: String,
+    windows_version: String,
+    macos_version: String,
+    service_nickname: Option<String>,
+    service_icon: Option<String>,
+    service_link: Option<LinkFragment>,
+    link: Option<LinkFragment>,
+    service: Option<bool>,
+    fw: Option<bool>, // Its name should be changed.
+    r#ref: String, // Its name must be changed!
+    ad: Option<bool>, // Maybe is_ad?
+}
+
+pub struct KakaoLinkInfo {
+    app_id: String,
+    template_id: Option<String>,
+    link_version: Option<String>,
+    app_key: Option<String>,
+    app_version: Option<String>,
+}
+
+pub struct CustomAttachment {
+    info: CustomInfo,
+    content: Option<CustomContent>,
+    link_info: Option<KakaoLinkInfo>,
+}

--- a/src/types/chat/attachment/custom.rs
+++ b/src/types/chat/attachment/custom.rs
@@ -1,3 +1,6 @@
+use serde::{Serialize, Deserialize};
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum CustomType {
     Feed,
     List,
@@ -5,66 +8,101 @@ pub enum CustomType {
     Carousel,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum ButtonStyle {
-    Horizontal,
-    Vertical,
+    Horizontal = 0,
+    Vertical = 1,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum ButtonDisplayTarget {
+    #[serde(rename = "Both")]
     All,
+    #[serde(rename = "sender")]
     Sender,
+    #[serde(rename = "receiver")]
     Receiver,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum ImageCropStyle {
     Square = 0,
     None = 1,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct TextFragment {
+    #[serde(rename = "T")]
     text: String,
+    #[serde(rename = "D")]
     description: String,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct LinkFragment {
+    #[serde(rename = "LPC")]
     windows_link: String,
+    #[serde(rename = "LMO")]
     macos_link: String,
+    #[serde(rename = "LCA")]
     android_link: String,
+    #[serde(rename = "LCI")]
     ios_link: String,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ImageFragment {
+    #[serde(rename = "THU")]
     url: String,
+    #[serde(rename = "W")]
     width: u32,
+    #[serde(rename = "H")]
     height: u32,
+    #[serde(rename = "SC")]
     crop_style: ImageCropStyle,
+    #[serde(rename = "LI")]
     is_live: bool,
+    #[serde(rename = "PT")]
     playtime: u32,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ButtonFragment {
     text: String,
     display_target: Option<ButtonDisplayTarget>,
     link: LinkFragment,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SocialFragment {
+    #[serde(rename = "LK")]
     link: u32,
+    #[serde(rename = "CM")]
     comment: u32,
+    #[serde(rename = "SH")]
     share: u32,
+    #[serde(rename = "VC")]
     view: u32,
+    #[serde(rename = "SB")]
     subscriber: u32,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ProfileFragment {
+    #[serde(rename = "TD")]
     description: TextFragment,
+    #[serde(rename = "L")]
     link: LinkFragment,
+    #[serde(rename = "BG")]
     background_image: ImageFragment,
+    #[serde(rename = "TH")]
     thumbnail_image: ImageFragment,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct CustomContent { }
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct CustomFeedContent {
     description: TextFragment,
     button_style: ButtonStyle,
@@ -78,49 +116,85 @@ pub struct CustomFeedContent {
     social: Option<SocialFragment>,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct CarouselCover {
+    #[serde(rename = "TD")]
     text: TextFragment,
+    #[serde(rename = "TH")]
     thumbnail_image: Option<ImageFragment>,
+    #[serde(rename = "BG")]
     background_image: Option<ImageFragment>,
+    #[serde(rename = "L")]
     link: Option<LinkFragment>,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct CustomCarouselContent {
     card_type: CustomType,
+    #[serde(rename = "CIL")]
     content_list: Vec<CustomContent>,
+    #[serde(rename = "CHD")]
     content_head: Option<CarouselCover>,
+    #[serde(rename = "CTA")]
     content_tail: Option<CarouselCover>,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct CustomInfo {
+    #[serde(rename = "ME")]
     message: String,
+    #[serde(rename = "TP")]
     custom_type: CustomType,
+    #[serde(rename = "SID")]
     service_id: String,
+    #[serde(rename = "DID")]
     provider_id: String,
+    #[serde(rename = "VA")]
     android_version: String,
+    #[serde(rename = "VI")]
     ios_version: String,
+    #[serde(rename = "VW")]
     windows_version: String,
+    #[serde(rename = "VM")]
     macos_version: String,
+    #[serde(rename = "SNM")]
     service_nickname: Option<String>,
+    #[serde(rename = "SIC")]
     service_icon: Option<String>,
+    #[serde(rename = "SL")]
     service_link: Option<LinkFragment>,
+    #[serde(rename = "L")]
     link: Option<LinkFragment>,
-    service: Option<bool>,
+    #[serde(rename = "LOCK")]
+    secure: Option<bool>,
+    #[serde(rename = "FW")]
     fw: Option<bool>, // Its name should be changed.
+    #[serde(rename = "RF")]
     r#ref: String, // Its name must be changed!
+    #[serde(rename = "AD")]
     ad: Option<bool>, // Maybe is_ad?
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct KakaoLinkInfo {
+    #[serde(rename = "ai")]
     app_id: String,
+    #[serde(rename = "ti")]
     template_id: Option<String>,
+    #[serde(rename = "lv")]
     link_version: Option<String>,
+    #[serde(rename = "ak")]
     app_key: Option<String>,
+    #[serde(rename = "av")]
     app_version: Option<String>,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct CustomAttachment {
+    #[serde(rename = "P")]
     info: CustomInfo,
+    #[serde(rename = "C")]
     content: Option<CustomContent>,
+    #[serde(rename = "K")]
     link_info: Option<KakaoLinkInfo>,
 }

--- a/src/types/chat/attachment/custom.rs
+++ b/src/types/chat/attachment/custom.rs
@@ -16,7 +16,7 @@ pub enum ButtonStyle {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum ButtonDisplayTarget {
-    #[serde(rename = "Both")]
+    #[serde(rename = "both")]
     All,
     #[serde(rename = "sender")]
     Sender,

--- a/src/types/chat/attachment/mod.rs
+++ b/src/types/chat/attachment/mod.rs
@@ -1,8 +1,10 @@
+mod custom;
 mod file;
 mod sharp;
 mod sticker;
 mod text;
 
+pub use custom::*;
 pub use file::*;
 pub use sharp::*;
 pub use sticker::*;


### PR DESCRIPTION
- 일부 구조체/변수/열거형의 이름을 [원본](https://github.com/storycraft/node-kakao/blob/master/src/talk/chat/attachment/custom-attachment.ts)과 다르게 했는데, 바꾼게 더 나은지 원본이 더 나은지 확인해주세요.

- custom.rs 파일의 110번째 줄을 보면 ref라는 이름의 필드가 있는데, 예약된 키워드 ref랑 겹쳐서 일단 r#ref로 작성했습니다. 이름을 바꿔야 하긴 한데, 이게 무슨 역할을 하는 필드인지 잘 모르겠습니다.